### PR TITLE
refactor: Adjust header link size in 1440px media query

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -292,7 +292,6 @@ footer img {
 @media screen and (max-width: 1440px) {
   .links li {
     margin: 0 25px;
-    font-size: 18px;
   }
 
   .scoreboard-player h2 {


### PR DESCRIPTION
# Pull Request

## Description
This PR updates the media queries to adjust header font size.

## Changes
- In the 1440px media query, removed font size from the .links li selector.

## Related Issues
N/a

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
None.

